### PR TITLE
fix: not signature in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:edge AS build
-RUN apk add --no-cache --update gcc g++ go make
+RUN apk add --no-cache --allow-untrusted --update gcc g++ go make
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
### summary

I found gcc and g++ packages are not UNTRUSTED signature packages, so  we can install the packages with `--allow-untrusted` argv.


```
=> ERROR [build 2/7] RUN apk add --no-cache --update gcc g++ go make                                                                                        7.2s
------
 > [build 2/7] RUN apk add --no-cache --update gcc g++ go make:
#0 0.297 fetch https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz
#0 6.047 fetch https://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/APKINDEX.tar.gz
#0 6.047 WARNING: Ignoring https://dl-cdn.alpinelinux.org/alpine/edge/main: UNTRUSTED signature
#0 7.190 WARNING: Ignoring https://dl-cdn.alpinelinux.org/alpine/edge/community: UNTRUSTED signature
#0 7.191 ERROR: unable to select packages:
#0 7.195   g++ (no such package):
#0 7.195     required by: world[g++]
#0 7.195   gcc (no such package):
#0 7.195     required by: world[gcc]
#0 7.195   go (no such package):
#0 7.195     required by: world[go]
#0 7.195   make (no such package):
#0 7.195     required by: world[make]
```