### PR TITLE
adds MONITOR command and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Command    Go API                Description
 -------    ------                -----------
 ECHO       -                     Returns the given string.
 PING       -                     Returns the server's liveliness response.
+MONITOR    -                     Streams back every command processed by the server.
 ```
 
 The rest of the server and connection management commands are not planned for 1.0.

--- a/internal/redis/redis.go
+++ b/internal/redis/redis.go
@@ -25,6 +25,7 @@ var (
 	ErrSyntaxError       = errors.New("ERR syntax error")
 	ErrUnknownCmd        = errors.New("ERR unknown command")
 	ErrUnknownSubcmd     = errors.New("ERR unknown subcommand")
+	ErrReplicaInteract   = errors.New("ERR Replica can't interact with the keyspace")
 )
 
 // Writer is an interface to write responses to the client.

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -42,10 +42,11 @@ func TestHandlers(t *testing.T) {
 type fakeConn struct {
 	parts []string
 	ctx   any
+	addr  string
 }
 
 func (c *fakeConn) RemoteAddr() string {
-	return ""
+	return c.addr
 }
 func (c *fakeConn) Close() error {
 	return nil

--- a/internal/server/monitor.go
+++ b/internal/server/monitor.go
@@ -1,0 +1,82 @@
+package server
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/nalgeon/redka/internal/redis"
+	"github.com/tidwall/redcon"
+)
+
+// monitors represents a set of connections that should receive a log of command requests.
+// Connections run in a detached state so we must be careful to flush and close
+// these connections ourselves.
+type monitors struct {
+	mu   sync.RWMutex
+	subs map[redcon.DetachedConn]bool
+}
+
+// subscribe will cause a connection to receive all monitored commands.
+func (m *monitors) subscribe(detached redcon.DetachedConn) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.subs == nil {
+		m.subs = make(map[redcon.DetachedConn]bool)
+	}
+	m.subs[detached] = true
+
+	go func() {
+		for {
+			cmd, err := detached.ReadCommand()
+			if err != nil {
+				m.unsubscribe(detached)
+				if err != io.EOF {
+					slog.Error("err on read", "client", detached.RemoteAddr(), "err", err)
+				}
+				return
+			}
+			name := normName(cmd)
+			switch name {
+			case "quit":
+				m.unsubscribe(detached)
+				detached.WriteString("OK")
+				_ = detached.Flush()
+				_ = detached.Close()
+				return
+			default:
+				detached.WriteError(redis.ErrReplicaInteract.Error())
+				_ = detached.Flush()
+			}
+		}
+	}()
+}
+
+// unsubscribe will prevent a detached connection from receiving any monitored commands.
+func (m *monitors) unsubscribe(detached redcon.DetachedConn) {
+	m.mu.Lock()
+	delete(m.subs, detached)
+	m.mu.Unlock()
+}
+
+// monitor sends a client's command log to all subscribed connections.
+func (m *monitors) monitor(t time.Time, db int, client redcon.Conn, cmd redcon.Command) {
+	if len(m.subs) == 0 {
+		return
+	}
+
+	secs := t.Unix()
+	microsecs := t.UnixNano() % 1e9 / 1e3
+	quotedCommand := bytes.Join(cmd.Args, []byte(`" "`))
+	line := fmt.Sprintf("%d.%06d [%d %s] \"%s\"", secs, microsecs, db, client.RemoteAddr(), quotedCommand)
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for detached := range m.subs {
+		detached.WriteString(line)
+		detached.Flush() // TODO: Maybe flush periodically in the background to reduce io overhead?
+	}
+}

--- a/internal/server/monitor_test.go
+++ b/internal/server/monitor_test.go
@@ -1,0 +1,164 @@
+package server
+
+import (
+	"regexp"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/nalgeon/redka"
+	"github.com/tidwall/redcon"
+)
+
+// TestMonitor ensures that the MONITOR command starts and stops appropriately
+func TestMonitor(t *testing.T) {
+	db, err := redka.Open(":memory:", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux := createHandlers(db)
+
+	monConn := newMonitorTestConn()
+
+	// MONITOR _must_ be the first command in the list for this to work
+	serveRESP := func(conn *monitorConn, cmd redcon.Command) string {
+		name := normName(cmd)
+		switch name {
+		// monitor command handled normally
+		case "monitor":
+			mux.ServeRESP(conn, cmd)
+		// subsequent commands handled in detached state
+		default:
+			conn.sendClientCommand(cmd)
+		}
+		return <-conn.lastOutCh
+	}
+
+	// send test client commands while monitoring.
+	tests := []struct {
+		cmd  redcon.Command
+		want string
+	}{
+		{
+			cmd: redcon.Command{
+				Raw:  []byte("MONITOR"),
+				Args: [][]byte{[]byte("MONITOR")},
+			},
+			want: "OK",
+		},
+		{
+			cmd: redcon.Command{
+				Raw:  []byte("GET foo"),
+				Args: [][]byte{[]byte("GET"), []byte("foo")},
+			},
+			want: "ERR Replica can't interact with the keyspace",
+		},
+		{
+			cmd: redcon.Command{
+				Raw:  []byte("QUIT"),
+				Args: [][]byte{[]byte("QUIT")},
+			},
+			want: "OK",
+		},
+	}
+	for _, test := range tests {
+		out := serveRESP(monConn, test.cmd)
+		if out != test.want {
+			t.Fatalf("want '%s', got '%s'", test.want, out)
+		}
+	}
+}
+
+// TestMonitor_OtherClient ensures that the MONITOR command gets notified when other clients send requests
+func TestMonitor_OtherClient(t *testing.T) {
+	db, err := redka.Open(":memory:", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux := createHandlers(db)
+
+	// Start monitoring
+	monConn := newMonitorTestConn()
+	mux.ServeRESP(monConn, redcon.Command{
+		Raw:  []byte("MONITOR"),
+		Args: [][]byte{[]byte("MONITOR")},
+	})
+	if out := <-monConn.lastOutCh; out != "OK" {
+		t.Fatalf("want '%s', got '%s'", "OK", out)
+	}
+
+	// send test client commands while monitoring.
+	tests := []struct {
+		cmd       redcon.Command
+		wantRegex string
+	}{
+		{
+			cmd: redcon.Command{
+				Raw:  []byte("ECHO hello"),
+				Args: [][]byte{[]byte("ECHO"), []byte("hello")},
+			},
+			wantRegex: `^\d{10}\.\d{6} \[0 localhost:22222\] "ECHO" "hello"$`,
+		},
+		{
+			cmd: redcon.Command{
+				Raw:  []byte("GET foo"),
+				Args: [][]byte{[]byte("GET"), []byte("foo")},
+			},
+			wantRegex: `^\d{10}\.\d{6} \[0 localhost:22222\] "GET" "foo"$`,
+		},
+	}
+	for _, test := range tests {
+		cmdConn := &fakeConn{addr: "localhost:22222"}
+		mux.ServeRESP(cmdConn, test.cmd)
+
+		out := <-monConn.lastOutCh
+		matched, err := regexp.MatchString(test.wantRegex, out)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if !matched {
+			t.Fatalf("want '%s', got '%s'", test.wantRegex, out)
+		}
+	}
+}
+
+type monitorConn struct {
+	*fakeConn
+	clientCommands chan redcon.Command
+	lastOutCh      chan string
+}
+
+func newMonitorTestConn() *monitorConn {
+	return &monitorConn{
+		fakeConn:       new(fakeConn),
+		clientCommands: make(chan redcon.Command, 1),
+		lastOutCh:      make(chan string, 1),
+	}
+}
+
+func (c *monitorConn) RemoteAddr() string {
+	return "localhost:11111"
+}
+
+func (c *monitorConn) Detach() redcon.DetachedConn {
+	return c
+}
+
+func (c *monitorConn) Close() error {
+	close(c.clientCommands)
+	return nil
+}
+
+func (dc *monitorConn) Flush() error {
+	dc.lastOutCh <- dc.parts[len(dc.parts)-1]
+	return nil
+}
+
+func (dc *monitorConn) ReadCommand() (redcon.Command, error) {
+	return <-dc.clientCommands, nil
+}
+
+func (c *monitorConn) sendClientCommand(cmd redcon.Command) {
+	c.clientCommands <- cmd
+}


### PR DESCRIPTION
Fixes https://github.com/nalgeon/redka/issues/23 by adding the "monitor" command.

## Compatibility
 
Behavior should be near-identical to what's documented here: https://redis.io/docs/latest/commands/monitor/

Once a monitor command is sent, the connection will stay open and stream all commands handled by the server. This works both via redis-cli as well as telnet. Meaning, a SIGINT (CTRL-C) sent from the redis-cli or a "quit" command sent over telnet will both stop monitoring gracefully.

MULTI commands are handled appropriately as well, meaning a "multi" command will be logged immediately, but queued commands will only log _after_ "exec" is sent ("exec" is logged last in the monitor output).

## Internals

I made one change to how the handler chain works. Instead of pure functions, I added a `handlers` type in order to share monitoring subscriptions across the handler chain (it's how I ensure that "multi" and related commands get logged appropriately).

I also added a `monitors` type which represents a set of connections that subscribe to command request logs. Connections run in a detached state so it handles reading, flushing, and closing. It also manages the subscription pool to fan out monitor logs appropriately.

## Testing

There are two monitor tests: One which verifies that starting and stoping the monitor command work as expected. And one which verifies that commands from other clients are written out as expected.

I haven't performed any benchmarks.

Happy to take feedback or make changes :)