### PR TITLE
Fix macOS amd64 build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,9 @@ jobs:
                       asset_name: redka_linux_amd64.zip
                     - os: macos-latest
                       goos: darwin
+                      asset_name: redka_darwin_arm64.zip
+                    - os: macos-13
+                      goos: darwin
                       asset_name: redka_darwin_amd64.zip
         steps:
             - name: Check out code

--- a/README.md
+++ b/README.md
@@ -257,10 +257,21 @@ unzip redka_linux_amd64.zip
 chmod +x redka
 ```
 
-macOS (both x86 and ARM/Apple Silicon CPU):
+macOS (x86 CPU):
 
 ```shell
 curl -L -O "https://github.com/nalgeon/redka/releases/download/v0.5.0/redka_darwin_amd64.zip"
+unzip redka_darwin_amd64.zip
+# remove the build from quarantine
+# (macOS disables unsigned binaries)
+xattr -d com.apple.quarantine redka
+chmod +x redka
+```
+
+macOS (ARM/Apple Silicon CPU):
+
+```shell
+curl -L -O "https://github.com/nalgeon/redka/releases/download/v0.5.0/redka_darwin_arm64.zip"
 unzip redka_darwin_amd64.zip
 # remove the build from quarantine
 # (macOS disables unsigned binaries)


### PR DESCRIPTION
The `macos-latest` label currently uses the macOS 14 M1 runner[^1], the `redka_darwin_amd64.zip` release is actually an arm64 only binary.

```
❯ curl -sSL -O "https://github.com/nalgeon/redka/releases/download/v0.5.0/redka_darwin_amd64.zip"

❯ unzip redka_darwin_amd64.zip
Archive:  redka_darwin_amd64.zip
  inflating: redka

❯ file ./redka
./redka: Mach-O 64-bit executable arm64

❯ ./redka
exec: Failed to execute process './redka': Bad CPU type in executable.
```

[^1]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#standard-github-hosted-runners-for-public-repositories