### PR TITLE
feat: read-only mode (#30)

### DIFF
--- a/redka_test.go
+++ b/redka_test.go
@@ -20,6 +20,34 @@ func ExampleOpen() {
 	// ...
 }
 
+func ExampleOpenRead() {
+	// open a writable database
+	db, err := redka.Open("data.db", nil)
+	if err != nil {
+		panic(err)
+	}
+	db.Str().Set("name", "alice")
+	db.Close()
+
+	// open a read-only database
+	db, err = redka.OpenRead("data.db", nil)
+	if err != nil {
+		panic(err)
+	}
+	// read operations work fine
+	name, _ := db.Str().Get("name")
+	fmt.Println(name)
+	// write operations will fail
+	err = db.Str().Set("name", "bob")
+	fmt.Println(err)
+	// attempt to write a readonly database
+	db.Close()
+
+	// Output:
+	// alice
+	// attempt to write a readonly database
+}
+
 func ExampleDB_Close() {
 	db, err := redka.Open("file:/data.db?vfs=memdb", nil)
 	if err != nil {


### PR DESCRIPTION
Functions to open the database in read-only mode to work with read replicas:

```go
// OpenRead opens an existing database at the given path in read-only mode.
func OpenRead(path string, opts *Options) (*DB, error)

// OpenReadDB connects to an existing SQL database in read-only mode.
func OpenReadDB(db *sql.DB, opts *Options) (*DB, error)
```