### PR TITLE
Add order by id to rkey table scan

### DIFF
--- a/internal/rkey/tx.go
+++ b/internal/rkey/tx.go
@@ -84,6 +84,7 @@ const (
 	where
 		id > ? and key glob ? and (type = ? or true)
 		and (etime is null or etime > ?)
+	order by id asc
 	limit ?`
 )
 
@@ -347,10 +348,8 @@ func (tx *Tx) Scan(cursor int, pattern string, ktype core.TypeID, count int) (Sc
 
 	// Select the maximum ID.
 	maxID := 0
-	for _, key := range keys {
-		if key.ID > maxID {
-			maxID = key.ID
-		}
+	if len(keys) > 0 {
+		maxID = keys[len(keys)-1].ID
 	}
 
 	return ScanResult{maxID, keys}, nil


### PR DESCRIPTION
SQLite does not guarantee the order of row returns by default unless the ORDER BY clause is explicitly specified in the query. This can lead to unpredictable results. If the order is not fixed, there is a possibility that some rows may be lost between queries.

For example:
```
id > 0 limit 5 -- returns [1, 2, 3, 4, 10]
```
Values [5, 6, 7, 8, 9] are missing.

```
id > 10 limit 5 -- returns [11, ...]
```