### PR TITLE
Add basic `EVAL` command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22
 require (
 	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/tidwall/redcon v1.6.2
+	github.com/yuin/gopher-lua v1.1.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -7,3 +7,5 @@ github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/redcon v1.6.2 h1:5qfvrrybgtO85jnhSravmkZyC0D+7WstbfCs3MmPhow=
 github.com/tidwall/redcon v1.6.2/go.mod h1:p5Wbsgeyi2VSTBWOcA5vRXrOb9arFTcU2+ZzFjqV75Y=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=

--- a/internal/command/eval/eval_test.go
+++ b/internal/command/eval/eval_test.go
@@ -1,0 +1,67 @@
+package eval
+
+import (
+	"testing"
+
+	"github.com/nalgeon/redka/internal/redis"
+	"github.com/nalgeon/redka/internal/testx"
+)
+
+func TestEvalParse(t *testing.T) {
+	tests := []struct {
+		cmd  redis.BaseCmd
+		want Eval
+		err  error
+	}{
+		{
+			cmd:  redis.NewBaseCmd([][]byte{[]byte("EVAL"), []byte("return 0"), []byte("0")}),
+			want: Eval{script: "return 0", keys: []string(nil), args: []string(nil)},
+			err:  nil,
+		},
+		{
+			cmd:  redis.NewBaseCmd([][]byte{[]byte("EVAL"), []byte("return 0"), []byte("1"), []byte("key1")}),
+			want: Eval{script: "return 0", keys: []string{"key1"}, args: []string(nil)},
+			err:  nil,
+		},
+		{
+			cmd:  redis.NewBaseCmd([][]byte{[]byte("EVAL"), []byte("return 0"), []byte("2"), []byte("key1"), []byte("key2")}),
+			want: Eval{script: "return 0", keys: []string{"key1", "key2"}, args: []string(nil)},
+			err:  nil,
+		},
+		{
+			cmd:  redis.NewBaseCmd([][]byte{[]byte("EVAL"), []byte("return 0"), []byte("1"), []byte("key1"), []byte("arg1")}),
+			want: Eval{script: "return 0", keys: []string{"key1"}, args: []string{"arg1"}},
+			err:  nil,
+		},
+		{
+			cmd:  redis.NewBaseCmd([][]byte{[]byte("EVAL"), []byte("return 0"), []byte("0"), []byte("arg1"), []byte("arg2")}),
+			want: Eval{script: "return 0", keys: []string{}, args: []string{"arg1", "arg2"}},
+			err:  nil,
+		},
+		{
+			cmd:  redis.NewBaseCmd([][]byte{[]byte("EVAL")}),
+			want: Eval{},
+			err:  redis.ErrInvalidArgNum,
+		},
+		{
+			cmd:  redis.NewBaseCmd([][]byte{[]byte("EVAL"), []byte("return 0")}),
+			want: Eval{},
+			err:  redis.ErrInvalidArgNum,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.cmd.String(), func(t *testing.T) {
+			// redis.Parse does not play well with quoted strings
+			cmd, err := ParseEval(test.cmd)
+			testx.AssertEqual(t, err, test.err)
+			if err == nil {
+				testx.AssertEqual(t, cmd.script, test.want.script)
+				testx.AssertEqual(t, cmd.keys, test.want.keys)
+				testx.AssertEqual(t, cmd.args, test.want.args)
+			} else {
+				testx.AssertEqual(t, cmd, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is an initial implementation of the `EVAL` command from redis. It is currently very barebones and only the `redis.call` function is available.

I want to open this PR to get some feedback as I am a Go noob so if there are any suggestions you are welcome to give feedback.