### PR TITLE
add support for named pipes (Unix domain sockets). 

### DIFF
--- a/cmd/redka/main.go
+++ b/cmd/redka/main.go
@@ -44,6 +44,7 @@ pragma foreign_keys = on;`
 type Config struct {
 	Host    string
 	Port    string
+	FIFO    string
 	Path    string
 	Verbose bool
 }
@@ -62,6 +63,7 @@ func init() {
 	}
 	flag.StringVar(&config.Host, "h", "localhost", "server host")
 	flag.StringVar(&config.Port, "p", "6379", "server port")
+	flag.StringVar(&config.FIFO, "F", "", "server FIFO")
 	flag.BoolVar(&config.Verbose, "v", false, "verbose logging")
 
 	// Register an SQLite driver with custom pragmas.
@@ -120,7 +122,13 @@ func main() {
 	slog.Info("data source", "path", config.Path)
 
 	// Start the server.
-	srv := server.New(config.Addr(), db)
+
+        var srv *server.Server
+        if config.FIFO == "" {
+	  srv = server.New("tcp", config.Addr(), db)
+        } else {
+	  srv = server.New("unix", config.FIFO, db)
+        }
 	srv.Start()
 
 	// Wait for a shutdown signal.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 
 // Server represents a Redka server.
 type Server struct {
+	net  string
 	addr string
 	srv  *redcon.Server
 	db   *redka.DB
@@ -18,7 +19,7 @@ type Server struct {
 }
 
 // New creates a new Redka server.
-func New(addr string, db *redka.DB) *Server {
+func New(net string, addr string, db *redka.DB) *Server {
 	handler := createHandlers(db)
 	accept := func(conn redcon.Conn) bool {
 		slog.Info("accept connection", "client", conn.RemoteAddr())
@@ -31,9 +32,10 @@ func New(addr string, db *redka.DB) *Server {
 			slog.Debug("close connection", "client", conn.RemoteAddr())
 		}
 	}
-	return &Server{
+        return &Server{
+                net: net,
 		addr: addr,
-		srv:  redcon.NewServer(addr, handler, accept, closed),
+		srv:  redcon.NewServerNetwork(net, addr, handler, accept, closed),
 		db:   db,
 		wg:   &sync.WaitGroup{},
 	}


### PR DESCRIPTION
Proof of concept for #41. Demonstrates named pipes working ok on Mac. 

All existing tests continue to pass. No new tests in go but did some manual tests on mac with Python client. 

```
/build/redka -F /tmp/redka_unix.sock
```

```python
from redis.client import Redis
r = Redis(unix_socket_path='/tmp/redka_unix.sock')
```

